### PR TITLE
🐛 Fix compiler error (#100)

### DIFF
--- a/packages/admin-app/src/components/ElectionSetupWizard/ElectionSetupWizard.tsx
+++ b/packages/admin-app/src/components/ElectionSetupWizard/ElectionSetupWizard.tsx
@@ -1,4 +1,4 @@
-import { AsyncResult, JointKey, getGuardianApiClient } from '@electionguard/api-client';
+import { AsyncResult, JointKey, ApiClientFactory } from '@electionguard/api-client';
 import { Box } from '@material-ui/core';
 import React, { useState } from 'react';
 
@@ -37,7 +37,7 @@ export const ElectionSetupWizard: React.FC<ElectionSetupWizardProps> = ({ getKey
     const { nextStep } = createEnumStepper(ElectionSetupStep);
     const next = () => setStep(nextStep(step));
 
-    const service = getGuardianApiClient();
+    const service = ApiClientFactory.getGuardianApiClient();
     return (
         <Box height="100%">
             <WizardStep active={step === ElectionSetupStep.Instructions}>

--- a/packages/admin-app/src/components/ElectionSetupWizard/Steps/ManifestPreviewStep.stories.tsx
+++ b/packages/admin-app/src/components/ElectionSetupWizard/Steps/ManifestPreviewStep.stories.tsx
@@ -1,6 +1,5 @@
-import { getGuardianApiClient } from '@electionguard/api-client';
+import { ApiClientFactory } from '@electionguard/api-client';
 import { Meta, Story } from '@storybook/react';
-import React from 'react';
 
 import ManifestPreviewStep, { ManifestPreviewStepProps } from './ManifestPreviewStep';
 
@@ -12,7 +11,7 @@ export default {
 
 const Template: Story<ManifestPreviewStepProps> = (props) => <ManifestPreviewStep {...props} />;
 
-const service = getGuardianApiClient();
+const service = ApiClientFactory.getGuardianApiClient();
 export const Standard = Template.bind({});
 Standard.storyName = 'Standard';
 Standard.args = {

--- a/packages/api-client/.eslintrc.json
+++ b/packages/api-client/.eslintrc.json
@@ -4,6 +4,7 @@
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
-        "import/extensions": "off"
+        "import/extensions": "off",
+        "import/prefer-default-export": "off"
     }
 }

--- a/packages/api-client/src/api/ApiClientFactory.ts
+++ b/packages/api-client/src/api/ApiClientFactory.ts
@@ -6,6 +6,7 @@ import MockMediatorApi from './MockMediatorApi';
 
 export default class ApiClientFactory {
     private static mediatorClient: ElectionGuardMediatorApiClient;
+
     private static guardianClient: ElectionGuardGuardianApiClient;
 
     public static getGuardianApiClient(): ElectionGuardGuardianApiClient {

--- a/packages/api-client/src/api/ApiClientFactory.ts
+++ b/packages/api-client/src/api/ApiClientFactory.ts
@@ -4,7 +4,7 @@ import MediatorApi from './MediatorApi';
 import MockGuardianApi from './MockGuardianApi';
 import MockMediatorApi from './MockMediatorApi';
 
-export default class ApiClientFactory {
+export class ApiClientFactory {
     private static mediatorClient: ElectionGuardMediatorApiClient;
 
     private static guardianClient: ElectionGuardGuardianApiClient;

--- a/packages/api-client/src/api/ApiClientFactory.ts
+++ b/packages/api-client/src/api/ApiClientFactory.ts
@@ -1,0 +1,30 @@
+import ElectionGuardGuardianApiClient, { ElectionGuardMediatorApiClient } from './Api';
+import GuardianApi from './GuardianApi';
+import MediatorApi from './MediatorApi';
+import MockGuardianApi from './MockGuardianApi';
+import MockMediatorApi from './MockMediatorApi';
+
+export default class ApiClientFactory {
+    private static mediatorClient: ElectionGuardMediatorApiClient;
+    private static guardianClient: ElectionGuardGuardianApiClient;
+
+    public static getGuardianApiClient(): ElectionGuardGuardianApiClient {
+        if (!ApiClientFactory.guardianClient) {
+            ApiClientFactory.guardianClient =
+                process.env.REACT_APP_MOCK_ENABLED === 'true'
+                    ? new MockGuardianApi()
+                    : new GuardianApi();
+        }
+        return ApiClientFactory.guardianClient;
+    }
+
+    public static getMediatorApiClient(): ElectionGuardMediatorApiClient {
+        if (!ApiClientFactory.mediatorClient) {
+            ApiClientFactory.mediatorClient =
+                process.env.REACT_APP_MOCK_ENABLED === 'true'
+                    ? new MockMediatorApi()
+                    : new MediatorApi();
+        }
+        return ApiClientFactory.mediatorClient;
+    }
+}

--- a/packages/api-client/src/api/functions.ts
+++ b/packages/api-client/src/api/functions.ts
@@ -1,38 +1,6 @@
-import { ElectionGuardGuardianApiClient, ElectionGuardMediatorApiClient } from './Api';
-import GuardianApi from './GuardianApi';
-import MediatorApi from './MediatorApi';
-import MockGuardianApi from './MockGuardianApi';
-import MockMediatorApi from './MockMediatorApi';
-
 export interface UrlHolder {
     url: string;
 }
 
 export const filterByTerm = (inputArr: UrlHolder[], searchTerm: string): UrlHolder[] =>
     inputArr.filter((arrayElement) => arrayElement.url.match(searchTerm));
-
-let guardianClient: ElectionGuardGuardianApiClient;
-
-export function getGuardianApiClient(): ElectionGuardGuardianApiClient {
-    if (!guardianClient) {
-        guardianClient =
-            process.env.REACT_APP_MOCK_ENABLED === 'true'
-                ? new MockGuardianApi()
-                : new GuardianApi();
-    }
-    return guardianClient;
-}
-
-let mediatorClient: ElectionGuardMediatorApiClient;
-
-export function getMediatorApiClient(): ElectionGuardMediatorApiClient {
-    if (!mediatorClient) {
-        mediatorClient =
-            process.env.REACT_APP_MOCK_ENABLED === 'true'
-                ? new MockMediatorApi()
-                : new MediatorApi();
-    }
-    return mediatorClient;
-}
-
-export default getMediatorApiClient;

--- a/packages/api-client/src/api/index.ts
+++ b/packages/api-client/src/api/index.ts
@@ -1,2 +1,4 @@
 export * from './Api';
 export * from './functions';
+
+export { ApiClientFactory } from './ApiClientFactory';

--- a/packages/api-client/src/data/queries.ts
+++ b/packages/api-client/src/data/queries.ts
@@ -1,5 +1,5 @@
 import { useQuery } from 'react-query';
-import ApiClientFactory from '../api/ApiClientFactory';
+import { ApiClientFactory } from '../api/ApiClientFactory';
 
 import { BaseJointKey, JointKey, User, Election, KeyCeremony } from '../models';
 import { AsyncResult } from './AsyncResult';

--- a/packages/api-client/src/data/queries.ts
+++ b/packages/api-client/src/data/queries.ts
@@ -1,32 +1,32 @@
 import { useQuery } from 'react-query';
+import ApiClientFactory from '../api/ApiClientFactory';
 
 import { BaseJointKey, JointKey, User, Election, KeyCeremony } from '../models';
-import { getMediatorApiClient, getGuardianApiClient } from '../api';
 import { AsyncResult } from './AsyncResult';
 import { QUERY_NAMES } from './query_names';
 
 export function useGetUsersWithGuardianRole(): AsyncResult<User[]> {
-    const service = getGuardianApiClient();
+    const service = ApiClientFactory.getGuardianApiClient();
     return useQuery(QUERY_NAMES.GUARDIANS, () => service.findGuardians());
 }
 
 export function useCreateJointKey(data: BaseJointKey): AsyncResult<boolean> {
-    const service = getMediatorApiClient();
+    const service = ApiClientFactory.getMediatorApiClient();
     return useQuery(QUERY_NAMES.CREATE_KEY, () => service.postJointKey(data));
 }
 
 export function useGetJointKeys(): AsyncResult<JointKey[]> {
-    const service = getMediatorApiClient();
+    const service = ApiClientFactory.getMediatorApiClient();
     return useQuery(QUERY_NAMES.JOINT_KEYS, () => service.getJointKeys());
 }
 
 export function useGetElection(election_id: string): AsyncResult<Election[]> {
-    const service = getMediatorApiClient();
+    const service = ApiClientFactory.getMediatorApiClient();
     return useQuery(QUERY_NAMES.ELECTIONS, () => service.getElection(election_id));
 }
 
 export function useGetKeyCeremonies(): AsyncResult<KeyCeremony[]> {
-    const service = getMediatorApiClient();
+    const service = ApiClientFactory.getMediatorApiClient();
     return useQuery(QUERY_NAMES.KEY_CEREMONIES, () => service.getKeyCeremonies(''));
 }
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,5 +1,3 @@
 export * from './api';
 export * from './data';
 export * from './models';
-
-export { default as ApiClientFactory } from './api/ApiClientFactory';

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,7 +1,5 @@
+export * from './api';
 export * from './data';
 export * from './models';
-
-import * as Api from './api/index';
-export { Api };
 
 export { default as ApiClientFactory } from './api/ApiClientFactory';

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,3 +1,3 @@
-export * from './api';
+export * from './api/index';
 export * from './data';
 export * from './models';

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,3 +1,7 @@
-export * from './api';
 export * from './data';
 export * from './models';
+
+import * as Api from './api/index';
+export { Api };
+
+export { default as ApiClientFactory } from './api/ApiClientFactory';

--- a/packages/library/src/components/ElectionSetupWizard/Steps/ManifestPreviewStep.stories.tsx
+++ b/packages/library/src/components/ElectionSetupWizard/Steps/ManifestPreviewStep.stories.tsx
@@ -1,6 +1,5 @@
-import { getGuardianApiClient } from '@electionguard/api-client';
+import { ApiClientFactory } from '@electionguard/api-client';
 import { Meta, Story } from '@storybook/react';
-import React from 'react';
 
 import ManifestPreviewStep, { ManifestPreviewStepProps } from './ManifestPreviewStep';
 
@@ -12,7 +11,7 @@ export default {
 
 const Template: Story<ManifestPreviewStepProps> = (props) => <ManifestPreviewStep {...props} />;
 
-const service = getGuardianApiClient();
+const service = ApiClientFactory.getGuardianApiClient();
 export const Standard = Template.bind({});
 Standard.storyName = 'Standard';
 Standard.args = {


### PR DESCRIPTION
### Issue

Fixes #100 

### Description

When running the api-client you used to get an error: `Module '"@electionguard/api-client"' has no exported member 'getGuardianApiClient`.  This fixes it.

### Testing

Run `make start`, it should run without errors and the admin-app should show up.
